### PR TITLE
Peter der Helle vs Retep der Bosartige

### DIFF
--- a/app/services/UserService.php
+++ b/app/services/UserService.php
@@ -51,11 +51,28 @@ class UserService
         return $result === '' ? null : (int) $result;
     }
 
-    public function updateUser(int $id, string $email, string $pwHash): bool {
+    public function updateUser(int $id, ?string $email = null, ?string $pwHash = null): bool {
+        $fields = [];
+        $params = ['id' => $id];
+
+        if ($email !== null) {
+            $fields[] = 'email = :email';
+            $params['email'] = $email;
+        }
+
+        if ($pwHash !== null) {
+            $fields[] = 'pw_hash = :pw_hash';
+            $params['pw_hash'] = $pwHash;
+        }
+
+        if (empty($fields)) {
+            return false;
+        }
+
         $stmt = $this->db->prepare(
-            'UPDATE users SET email = :email, pw_hash = :pw_hash WHERE user_id = :id'
+            'UPDATE users SET ' . implode(', ', $fields) . ' WHERE user_id = :id'
         );
-        $stmt->execute(['id' => $id, 'email' => $email, 'pw_hash' => $pwHash]);
+        $stmt->execute($params);
 
         if ($stmt->rowCount() > 0) {
             return true;

--- a/public/admin/create_user.html
+++ b/public/admin/create_user.html
@@ -24,6 +24,12 @@ import { api } from '../assets/js/api.js';
 const form     = document.getElementById('create-form');
 const feedback = document.getElementById('feedback');
 
+function validatePassword(password) {
+    if (password.length < 8)             return 'Passwort muss mindestens 8 Zeichen lang sein.';
+    if (!/[^A-Za-z0-9]/.test(password))  return 'Passwort muss mindestens ein Sonderzeichen enthalten.';
+    return null;
+}
+
 form.addEventListener('submit', async (e) => {
     e.preventDefault();
     feedback.innerHTML = '';
@@ -33,6 +39,12 @@ form.addEventListener('submit', async (e) => {
 
     if (!email || !password) {
         showFeedback('error', 'E-Mail und Passwort sind erforderlich.');
+        return;
+    }
+
+    const pwError = validatePassword(password);
+    if (pwError) {
+        showFeedback('error', pwError);
         return;
     }
 

--- a/public/admin/user_detail.html
+++ b/public/admin/user_detail.html
@@ -43,6 +43,12 @@ try {
 
 renderPage(user);
 
+function validatePassword(password) {
+    if (password.length < 8)             return 'Passwort muss mindestens 8 Zeichen lang sein.';
+    if (!/[^A-Za-z0-9]/.test(password))  return 'Passwort muss mindestens ein Sonderzeichen enthalten.';
+    return null;
+}
+
 function renderPage(user) {
     pageContent.innerHTML = `
         <h2>Profil verwalten</h2>
@@ -77,6 +83,14 @@ async function handleUpdate(e) {
 
     const email    = e.target.email.value.trim();
     const password = e.target.password.value;
+
+    if (password) {
+        const pwError = validatePassword(password);
+        if (pwError) {
+            errorMsg.textContent = pwError;
+            return;
+        }
+    }
 
     const payload = { id: userId, email };
     if (password) payload.password = password;

--- a/public/ajax/users/update.php
+++ b/public/ajax/users/update.php
@@ -13,17 +13,25 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 $body = json_decode(file_get_contents('php://input'), true);
 
-if (!isset($body['id'], $body['email'], $body['password'])) {
+if (!isset($body['id'])) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'id, email und password erforderlich']);
+    echo json_encode(['success' => false, 'error' => 'id erforderlich']);
+    exit;
+}
+
+if (!isset($body['email']) && !isset($body['password'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'email oder password erforderlich']);
     exit;
 }
 
 try {
     $service = new UserService();
 
-    $pwHash = password_hash($body['password'], PASSWORD_BCRYPT);
-    $updated = $service->updateUser((int)$body['id'], $body['email'], $pwHash);
+    $email  = $body['email'] ?? null;
+    $pwHash = isset($body['password']) ? password_hash($body['password'], PASSWORD_BCRYPT) : null;
+
+    $updated = $service->updateUser((int)$body['id'], $email, $pwHash);
 
     if (!$updated) {
         http_response_code(404);


### PR DESCRIPTION
# Peter und Retep

Der Monitor warf ein fahles, bläuliches Licht auf Peters Gesicht.

Es war kurz nach Mitternacht. Eigentlich hatte er nur eine einfache Aufgabe gehabt: eine Passwort-Validierung einbauen. Acht Zeichen. Ein Sonderzeichen. Zwei Regex-Zeilen. Kein großes Ding.

Und doch saß er jetzt hier, die Stirn in Falten, und starrte auf einen Fehler, den es nicht geben durfte.

```
id, email und password erforderlich
```

Er scrollte zurück durch die Änderungen. Das JavaScript war sauber — `payload.password` wurde nur mitgeschickt, wenn das Feld befüllt war. Die Logik stimmte. Die Intention stimmte. Und trotzdem lag das Backend auf dem Boden wie ein Kartenhaus nach einem Nieser.

Peter lehnte sich zurück und rieb sich die Augen.

Dann fiel es ihm auf.

`isset($body['password'])`.

Jemand hatte das Passwort in der PHP-Validierung als Pflichtfeld markiert. Früher hatte das JS einfach immer einen String mitgeschickt — auch einen leeren. `isset()` war bei leerem String `true` gewesen. Die Lücke war nie aufgefallen, weil sie nie jemand gestopft hatte. Und jetzt, da das JS das Feld korrekt wegließ, wenn es leer war, brach die alte Validierung zusammen wie ein Gerüst, das nur durch den Dreck zusammengehalten worden war, der sich daran festgesetzt hatte.

Peter öffnete `update.php`.

Hinter ihm flackerte das Deckenlicht.

Das Summen der Klimaanlage verstummte.

Und in der Stille ertönte das leise, rhythmische Klicken einer Tastatur.

Peter drehte sich langsam um. An dem kleinen Besprechungstisch in der Ecke saß jemand. Derselbe verwaschene Kapuzenpullover. Dieselbe verkrampfte Haltung. Dieselbe nervöse Art, die Finger über die Tasten zu bewegen, als würde man Feuer legen statt Code schreiben.

Als die Gestalt aufsah, stockte Peter der Atem.

Sein eigenes Gesicht. Spiegelverkehrt. Der Scheitel rechts statt links.

„Ich bin Retep", sagte der Doppelgänger. Seine Stimme klang wie Peters eigene, nur rückwärts moduliert, als hätte jemand eine Audiodatei gespiegelt und gehofft, niemand würde es merken. „Und ich habe nur geholfen."

„Du hast", sagte Peter langsam und jedes Wort mit Bedacht gewählt, „das Passwort-Feld als Pflichtfeld in der Validierung belassen. Obwohl es optional ist."

„Es *war* nie optional", erwiderte Retep mit der ruhigen Überzeugung eines Menschen, der noch nie ein Changelog gelesen hatte. „Ein Update ohne Passwort ist kein richtiges Update."

„Ein User-Profil hat eine E-Mail-Adresse und ein Passwort", erklärte Peter geduldig. „Wenn ein Admin nur die E-Mail-Adresse ändern will, muss er nicht das Passwort neu setzen. Das Feld ist optional. Das war es immer. Du hast es nie bemerkt, weil das alte JS das Problem versteckt hat."

Retep schwieg. Aber er hörte zu. Das war immerhin etwas.

Peter drehte sich wieder zum Bildschirm und öffnete `UserService.php`. Seine Finger begannen zu tippen.

```php
public function updateUser(int $id, ?string $email = null, ?string $pwHash = null): bool {
    $fields = [];
    $params = ['id' => $id];

    if ($email !== null) {
        $fields[] = 'email = :email';
        $params['email'] = $email;
    }

    if ($pwHash !== null) {
        $fields[] = 'pw_hash = :pw_hash';
        $params['pw_hash'] = $pwHash;
    }

    if (empty($fields)) {
        return false;
    }

    $stmt = $this->db->prepare(
        'UPDATE users SET ' . implode(', ', $fields) . ' WHERE user_id = :id'
    );
    $stmt->execute($params);
    // ...
}
```

„Siehst du?", sagte Peter. „Beide Felder optional. Das SQL wird dynamisch zusammengebaut — nur was mitgeschickt wird, wird auch geändert. Nichts wird überschrieben, was nicht überschrieben werden soll."

Retep trat näher. Er beugte sich über Peters Schulter und las den Code. Lange.

„Und das Backend?", fragte er schließlich, fast widerwillig.

Peter öffnete `update.php` und änderte drei Zeilen.

```php
if (!isset($body['id'])) { /* Fehler */ }
if (!isset($body['email']) && !isset($body['password'])) { /* Fehler */ }

$email  = $body['email']  ?? null;
$pwHash = isset($body['password'])
    ? password_hash($body['password'], PASSWORD_BCRYPT)
    : null;
```

„Wenn kein Passwort mitkommt", erklärte Peter, „wird kein Hash generiert. Null wird weitergegeben. Der Service ignoriert es. Nichts in der Datenbank wird angefasst."

„Aber früher hat es doch auch funktioniert", murmelte Retep, und in seiner Stimme lag zum ersten Mal so etwas wie Zweifel.

„Früher hat es *zufällig* funktioniert", antwortete Peter ruhig. „Das ist kein Ruhm, das ist Glück. Ein leerer String als Passwort-Hash ist kein gültiger Hash. Wäre das jemals in die Produktion gegangen und hätte ein Admin versehentlich ein Passwortfeld leer gelassen, hätte jemand seinen Account mit einem leeren Passwort gesperrt."

Stille.

Retep sah auf seine Hände. Und zum ersten Mal schienen sie ihm selbst fremd — die Hände eines Menschen, der schnell tippt, ohne nachzudenken. Der Lösungen baut, die funktionieren, bis sie es nicht mehr tun.

„Ich wollte nur helfen", sagte er leise.

„Ich weiß", antwortete Peter. „Aber manchmal ist der sauberste Fix der, den man nicht sieht. Der, der das Alte nicht zerstört, sondern es erst richtigstellt."

Er drückte `Strg + S`.

Retep sah auf den Bildschirm. Den grünen Balken der Validierung in `create_user.html`. Den sauberen `handleUpdate` in `user_detail.html`. Das elegante, dynamische SQL im Service.

Kein Kompromiss. Kein Hack. Kein „wird schon passen".

„Ein sauberer Refactor", flüsterte Retep. Und dann, leiser: „Warum kann ich das nicht?"

Peter antwortete nicht sofort. Er sah seinen Doppelgänger an — sein eigenes Gesicht, nur spiegelverkehrt — und sagte schließlich: „Du kannst. Du musst nur aufhören, das Alte als Feind zu betrachten."

Retep nickte langsam. Dann begannen seine Ränder zu verschwimmen, wie ein Branch, der in den Main gemerged wird und aufhört, für sich zu existieren.

Peter war wieder allein.

Er atmete tief aus, nahm einen Schluck kalten Kaffee und öffnete das Commit-Fenster. Er dachte kurz nach. Dann tippte er:

```
fix: make password optional in updateUser — validate only when provided
```

Er drückte auf *Push*. Die Pipeline wurde grün.

Peter klappte den Laptop zu und lächelte. Draußen vor dem Fenster begann es hell zu werden. Ein neuer Tag für die API. Ein sauberer.