### PR TITLE
So das wurde getestet und schnurrt wie eine gatita

### DIFF
--- a/app/session/guard.php
+++ b/app/session/guard.php
@@ -57,7 +57,7 @@ function requireAuth_API(): void
 function requireSelforAdmin(int $targetUserId): void
 {
     requireAuth_API();
-    if ($_SESSION['account_id'] !== $targetUserId && !hasRole(ADMIN_ROLE_ID)) {
+    if ($_SESSION['account_id'] == $targetUserId || hasRole(ADMIN_ROLE_ID)) {
         http_response_code(403);
         header('Content-Type: application/json');
         echo json_encode(['success' => false, 'error' => 'Fehlende Berechtigung']);

--- a/app/session/guard.php
+++ b/app/session/guard.php
@@ -48,7 +48,7 @@ function requireAuth_API(): void
     if (!isAuthenticated()) {
         http_response_code(401);
         header('Content-Type: application/json');
-        echo json_encode(['success' => false, 'error' => 'Nicht authentisiert', 'code' => 401]);
+        echo json_encode(['success' => false, 'error' => 'Benutzer nicht authentisiert']);
         exit;
     }
 }
@@ -60,7 +60,19 @@ function requireSelforAdmin(int $targetUserId): void
     if ($_SESSION['account_id'] !== $targetUserId && !hasRole(ADMIN_ROLE_ID)) {
         http_response_code(403);
         header('Content-Type: application/json');
-        echo json_encode(['success' => false, 'error' => 'Fehlende Berechtigung', 'code' => 403]);
+        echo json_encode(['success' => false, 'error' => 'Fehlende Berechtigung']);
+        exit;
+    }
+}
+
+# Ticket #94: Funktion um API Endpunkte auf Admins zu beschränken
+function requireAdmin_API(): void
+{
+    requireAuth_API();
+    if (!hasRole(ADMIN_ROLE_ID)) {
+        http_response_code(403);
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'error' => 'Fehlende Berechtigung']);
         exit;
     }
 }

--- a/app/session/guard.php
+++ b/app/session/guard.php
@@ -57,7 +57,7 @@ function requireAuth_API(): void
 function requireSelforAdmin(int $targetUserId): void
 {
     requireAuth_API();
-    if ($_SESSION['account_id'] == $targetUserId || hasRole(ADMIN_ROLE_ID)) {
+    if ($_SESSION['account_id'] !== $targetUserId && !hasRole(ADMIN_ROLE_ID)) {
         http_response_code(403);
         header('Content-Type: application/json');
         echo json_encode(['success' => false, 'error' => 'Fehlende Berechtigung']);

--- a/public/ajax/group-members/create.php
+++ b/public/ajax/group-members/create.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/GroupMemberService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/group-members/delete.php
+++ b/public/ajax/group-members/delete.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/GroupMemberService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/groups/create.php
+++ b/public/ajax/groups/create.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/GroupService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/groups/delete.php
+++ b/public/ajax/groups/delete.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/GroupService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/groups/update.php
+++ b/public/ajax/groups/update.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/GroupService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/track-visible-groups/create.php
+++ b/public/ajax/track-visible-groups/create.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/TrackVisibleGroupService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/track-visible-groups/delete.php
+++ b/public/ajax/track-visible-groups/delete.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/TrackVisibleGroupService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/track-visible-users/create.php
+++ b/public/ajax/track-visible-users/create.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/TrackVisibleUserService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/track-visible-users/delete.php
+++ b/public/ajax/track-visible-users/delete.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/TrackVisibleUserService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/users.php
+++ b/public/ajax/users.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../app/services/UserService.php';
 require_once __DIR__ . '/../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 

--- a/public/ajax/users/create.php
+++ b/public/ajax/users/create.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../app/services/UserService.php';
 require_once __DIR__ . '/../../../app/helpers/Request.php';
 
 require_once __DIR__ . '/../../../app/session/guard.php';
-requireAdmin();
+requireAdmin_API();
 
 header('Content-Type: application/json');
 


### PR DESCRIPTION
Mahlzeit
Neue funktion in guard.php:
requireAdmin_API()
prüft zweistufig nach authentisierung und nach berechtigung.
Führt keine redirects durch

Das ganze wurde bereits in users.php implementiert.

MfG

#94 