### PR TITLE
Add route pacenotes API with GET and POST endpoints

### DIFF
--- a/app/services/RouteService.php
+++ b/app/services/RouteService.php
@@ -44,11 +44,15 @@ class RouteService
         return $stmt->fetchAll();
     }
 
-    public function createRoute(string $title, int $ownerUserId, string $jsonData): ?int
+    public function createRoute(?string $title, int $ownerUserId, string $jsonData): ?int
     {
+        if (json_decode($jsonData) === null) {
+            return null;
+        }
+
         $stmt = $this->db->prepare(
             'INSERT INTO tracks (title, owner_user_id, compiled_time, json_data)
-             VALUES (:title, :owner_user_id, CURRENT_TIMESTAMP, :json_data)'
+         VALUES (:title, :owner_user_id, CURRENT_TIMESTAMP, :json_data)'
         );
 
         $stmt->execute([
@@ -58,12 +62,15 @@ class RouteService
         ]);
 
         $lastInsertId = $this->db->lastInsertId();
-
         return $lastInsertId ? (int)$lastInsertId : null;
     }
 
     public function updateRoute(int $id, ?string $title = null, ?string $jsonData = null): bool
     {
+        if ($jsonData !== null && json_decode($jsonData) === null) {
+            return false;
+        }
+
         $fields = ['compiled_time = CURRENT_TIMESTAMP'];
         $params = ['id' => $id];
 
@@ -98,6 +105,10 @@ class RouteService
 
     public function updatePacenotes(int $routeId, string $jsonData): bool
     {
+        if (json_decode($jsonData) === null) {
+            return false;
+        }
+
         $stmt = $this->db->prepare(
             'UPDATE tracks SET pacenotes_data = :pacenotes_data WHERE route_id = :id'
         );

--- a/app/services/RouteService.php
+++ b/app/services/RouteService.php
@@ -116,6 +116,15 @@ class RouteService
         return $stmt->rowCount() > 0;
     }
 
+    public function getRoutePacenotes(int $routeId): ?string {
+        $stmt = $this->db->prepare(
+            'SELECT pacenotes_data FROM tracks WHERE route_id = :id'
+        );
+        $stmt->execute(['id' => $routeId]);
+        $result = $stmt->fetch();
+        return $result['pacenotes_data'] ?? null;
+    }
+
     // visible_for_user_id -> JOIN auf track_visible_user
     public function getRoutesByVisibleUserId(int $userId): array
     {

--- a/app/services/RouteService.php
+++ b/app/services/RouteService.php
@@ -78,7 +78,7 @@ class RouteService
         }
 
         $stmt = $this->db->prepare(
-            'UPDATE tracks SET ' . implode(', ', $fields) . ' WHERE track_id = :id'
+            'UPDATE tracks SET ' . implode(', ', $fields) . ' WHERE route_id = :id'
         );
         $stmt->execute($params);
 
@@ -93,6 +93,15 @@ class RouteService
 
         $stmt->execute(['id' => $id]);
 
+        return $stmt->rowCount() > 0;
+    }
+
+    public function updatePacenotes(int $routeId, string $jsonData): bool
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE tracks SET pacenotes_data = :pacenotes_data WHERE route_id = :id'
+        );
+        $stmt->execute(['pacenotes_data' => $jsonData, 'id' => $routeId]);
         return $stmt->rowCount() > 0;
     }
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -486,6 +486,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /ajax/routes/pacenotes.php:
+    get:
+      summary: Pacenotes einer Route abrufen
+      parameters:
+        - in: query
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pacenotes erfolgreich geladen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PacenotesGetResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      summary: Pacenotes einer Route speichern (Owner oder Admin)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PacenotesUpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /ajax/group-members.php:
     get:
       summary: Gruppenmitgliedschaften lesen
@@ -869,11 +911,35 @@ components:
         json_data:
           type: object
           additionalProperties: true
+        pacenotes_data:
+          type: object
+          nullable: true
+          additionalProperties: true
+
+    PacenotesGetResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          nullable: true
+          additionalProperties: true
       required:
-        - route_id
-        - owner_user_id
-        - compiled_time
-        - json_data
+        - success
+        - data
+
+    PacenotesUpdateRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+        pacenotes_data:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - pacenotes_data
 
     GroupMember:
       type: object

--- a/public/ajax/routes/pacenotes.php
+++ b/public/ajax/routes/pacenotes.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../app/services/RouteService.php';
+require_once __DIR__ . '/../../../app/helpers/Request.php';
+require_once __DIR__ . '/../../../app/session/guard.php';
+
+header('Content-Type: application/json');
+
+$service = new RouteService();
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    requireAuth_API();
+
+    if (!isset($_GET['id']) || (int)$_GET['id'] <= 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'id erforderlich']);
+        exit;
+    }
+
+    $route = $service->getRouteById((int)$_GET['id']);
+
+    if ($route === null) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Route nicht gefunden']);
+        exit;
+    }
+
+    echo json_encode(['success' => true, 'data' => $route['pacenotes_data'] ?? null]);
+
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    requireAuth_API();
+
+    $body = Request::getBody();
+    Request::requireFields($body, ['id', 'pacenotes_data']);
+    Request::requirePositiveInt($body, 'id');
+
+    $route = $service->getRouteById((int)$body['id']);
+
+    if ($route === null) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Route nicht gefunden']);
+        exit;
+    }
+
+    if ($route['owner_user_id'] !== $_SESSION['account_id'] && !hasRole(ADMIN_ROLE_ID)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'error' => 'Keine Berechtigung']);
+        exit;
+    }
+
+    $jsonData = json_encode($body['pacenotes_data']);
+
+    $updated = $service->updatePacenotes((int)$body['id'], $jsonData);
+
+    if (!$updated) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Pacenotes konnten nicht gespeichert werden']);
+        exit;
+    }
+
+    echo json_encode(['success' => true]);
+
+} else {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Methode nicht erlaubt']);
+}

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE tracks (
     owner_user_id INT NOT NULL,
     compiled_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     json_data JSON NOT NULL,
+    pacenote_data JSON NULL,
     FOREIGN KEY (owner_user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
```
Siehe Issue #111

### Summary

This pull request adds a new API endpoint `/ajax/routes/pacenotes.php` to manage route pacenotes. The endpoint supports both GET and POST methods, enabling retrieval and storage of pacenotes for specific routes.

### Changes Made

- Added `getRoutePacenotes` and `updatePacenotes` methods in `RouteService` for managing pacenotes.
- Updated OpenAPI documentation and schemas for the new endpoint.
- Validated JSON data in `RouteService` methods to ensure input integrity.
- Introduced `pacenote_data` column in the schema for storing pacenote information.
- Fixed a schema inconsistency by renaming `track_id` to `route_id` in update queries.

```